### PR TITLE
v2.0.1 - external image fix, render perf, docs polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm install

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # 🛍️ Shopping List Card
 [![GitHub Release][release_badge]][release]
+[![Downloads][downloads_badge]][release]
 [![Community Forum][forum_badge]][forum]
 [![Buy Me A Coffee][bmac_badge]][bmac]
 
 <!-- Link references -->
 [release_badge]: https://img.shields.io/github/v/release/eyalgal/ha-shopping-list-card
 [release]: https://github.com/eyalgal/ha-shopping-list-card/releases
+[downloads_badge]: https://img.shields.io/github/downloads/eyalgal/ha-shopping-list-card/total.svg
 [forum_badge]: https://img.shields.io/badge/Community-Forum-5294E2.svg
 [forum]: https://community.home-assistant.io/t/shopping-list-card-a-simple-card-for-quick-adding-items-to-any-to-do-list/905005
 [bmac_badge]: https://img.shields.io/badge/buy_me_a-coffee-yellow
@@ -78,10 +80,10 @@ haptic: true
 
 | Name | Type | Required | Description | Default |
 |---|---|---|---|---|
-| `type` | string | yes | Must be `custom:shopping-list-card`. | — |
-| `title` | string | yes | The item name. | — |
+| `type` | string | yes | Must be `custom:shopping-list-card`. | - |
+| `title` | string | yes | The item name. | - |
 | `subtitle` | string | no | A secondary line of text. Included when matching/writing: the stored item is `"<title> - <subtitle>"`. | `''` |
-| `todo_list` | string | yes | The `todo.<name>` entity to manage. | — |
+| `todo_list` | string | yes | The `todo.<name>` entity to manage. | - |
 | `list_prefix` | string | no | When set, items are stored as `"<prefix> - <title>"` for category sorting. Display is unchanged. | `''` |
 | `image` | string | no | URL to a custom image. Replaces the icon when set. | `''` |
 | `image_base` | string | no | Base path for auto-derived images. When set and `image` is empty, the card tries `<image_base><slug>.png` in several slug variants of the title. | `''` |
@@ -89,7 +91,7 @@ haptic: true
 | `show_name` | boolean | no | Set to `false` for an icon-only card. | `true` |
 | `enable_quantity` | boolean | no | Show `+` / `-` buttons when the item is on the list. | `false` |
 | `quantity_step` | number | no | How much `+` / `-` adjusts per tap. | `1` |
-| `quantity_max` | number | no | Optional cap for the quantity. | — |
+| `quantity_max` | number | no | Optional cap for the quantity. | - |
 | `on_icon` | string | no | Icon when the item is on the list. | `mdi:check` |
 | `on_color` | string | no | Color for the on state (HA name like `green`, `teal`, or `#4CAF50`). | `green` |
 | `off_icon` | string | no | Icon when the item is not on the list. | `mdi:plus` |
@@ -168,7 +170,7 @@ todo_list: todo.shopping_list
 
 ---
 
-### ❤️ Support
+## ❤️ Support
 
 If you find this card useful and would like to show your support, you can buy me a coffee:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-shopping-list-card",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Home Assistant Lovelace card to manage items on a to-do list",
   "main": "index.js",
   "scripts": {

--- a/shopping-list-card.js
+++ b/shopping-list-card.js
@@ -6,13 +6,13 @@
  *
  * Author: eyalgal
  * License: MIT
- * Version: 2.0.0
+ * Version: 2.0.1
  *
  * Note: This card requires a to-do entity to function properly.
  * For more information, visit: https://github.com/eyalgal/ha-shopping-list-card
  */
 
-const CARD_VERSION = '2.0.0';
+const CARD_VERSION = '2.0.1';
 
 function escapeHtml(str) {
   if (str == null) return '';
@@ -570,6 +570,7 @@ class ShoppingListCard extends HTMLElement {
     this._items = null;
     this._unsubscribe = null;
     this._subscribedEntity = null;
+    this._lastRenderKey = null;
   }
 
   set hass(hass) {
@@ -591,6 +592,8 @@ class ShoppingListCard extends HTMLElement {
     if (!config.todo_list) throw new Error('You must define a todo_list entity_id.');
     const prev = this._config;
     this._config = config;
+    // Any config change can affect what we render; invalidate the memo.
+    this._lastRenderKey = null;
     if (prev && prev.todo_list !== config.todo_list) {
       this._items = null;
       this._teardownSubscription();
@@ -762,6 +765,8 @@ class ShoppingListCard extends HTMLElement {
   _renderError(message) {
     this._ensureShell();
     this.content.innerHTML = `<ha-alert alert-type="error">${escapeHtml(message)}</ha-alert>`;
+    // Error replaces the card DOM, so the next normal render must rebuild from scratch.
+    this._lastRenderKey = null;
   }
 
   _render() {
@@ -789,6 +794,14 @@ class ShoppingListCard extends HTMLElement {
       const m = item.summary.match(rx);
       if (m) { isOn = true; matched = item.summary; matchedUid = item.uid; qty = m[1] ? +m[1] : 1; break; }
     }
+
+    // Memoize: skip the DOM rewrite when nothing visible (or interaction-relevant)
+    // changed for this card. Config changes invalidate _lastRenderKey via setConfig().
+    // This avoids rebuilding innerHTML on every WebSocket push that doesn't affect us
+    // (e.g. a sibling item being added on a 50-card dashboard).
+    const renderKey = `${isOn}|${qty}|${matchedUid || ''}|${matched || ''}`;
+    if (this._lastRenderKey === renderKey) return;
+    this._lastRenderKey = renderKey;
 
     const onIcon    = this._config.on_icon    || ShoppingListCard.DEFAULT_ON_ICON;
     const offIcon   = this._config.off_icon   || ShoppingListCard.DEFAULT_OFF_ICON;
@@ -827,7 +840,7 @@ class ShoppingListCard extends HTMLElement {
         let iconElement;
         if (effectiveImage) {
             iconElement = `<div class="image-wrapper vertical-image">
-                             <img src="${safeImage}" alt="${safeTitle}" crossorigin="anonymous" />
+                             <img src="${safeImage}" alt="${safeTitle}" />
                              ${quantityBadge}
                              <div class="icon-wrapper vertical-icon" style="background:${bg}; color:${fg};">
                                <ha-icon icon="${icon}"></ha-icon>
@@ -857,7 +870,7 @@ class ShoppingListCard extends HTMLElement {
 
         if (effectiveImage) {
             mainContent = `<div class="image-wrapper">
-                             <img src="${safeImage}" alt="${safeTitle}" crossorigin="anonymous" />
+                             <img src="${safeImage}" alt="${safeTitle}" />
                              <div class="icon-wrapper" style="background:${bg}; color:${fg};">
                                <ha-icon icon="${icon}"></ha-icon>
                              </div>

--- a/src/shopping-list-card.js
+++ b/src/shopping-list-card.js
@@ -6,13 +6,13 @@
  *
  * Author: eyalgal
  * License: MIT
- * Version: 2.0.0
+ * Version: 2.0.1
  *
  * Note: This card requires a to-do entity to function properly.
  * For more information, visit: https://github.com/eyalgal/ha-shopping-list-card
  */
 
-const CARD_VERSION = '2.0.0';
+const CARD_VERSION = '2.0.1';
 
 function escapeHtml(str) {
   if (str == null) return '';
@@ -570,6 +570,7 @@ class ShoppingListCard extends HTMLElement {
     this._items = null;
     this._unsubscribe = null;
     this._subscribedEntity = null;
+    this._lastRenderKey = null;
   }
 
   set hass(hass) {
@@ -591,6 +592,8 @@ class ShoppingListCard extends HTMLElement {
     if (!config.todo_list) throw new Error('You must define a todo_list entity_id.');
     const prev = this._config;
     this._config = config;
+    // Any config change can affect what we render; invalidate the memo.
+    this._lastRenderKey = null;
     if (prev && prev.todo_list !== config.todo_list) {
       this._items = null;
       this._teardownSubscription();
@@ -762,6 +765,8 @@ class ShoppingListCard extends HTMLElement {
   _renderError(message) {
     this._ensureShell();
     this.content.innerHTML = `<ha-alert alert-type="error">${escapeHtml(message)}</ha-alert>`;
+    // Error replaces the card DOM, so the next normal render must rebuild from scratch.
+    this._lastRenderKey = null;
   }
 
   _render() {
@@ -789,6 +794,14 @@ class ShoppingListCard extends HTMLElement {
       const m = item.summary.match(rx);
       if (m) { isOn = true; matched = item.summary; matchedUid = item.uid; qty = m[1] ? +m[1] : 1; break; }
     }
+
+    // Memoize: skip the DOM rewrite when nothing visible (or interaction-relevant)
+    // changed for this card. Config changes invalidate _lastRenderKey via setConfig().
+    // This avoids rebuilding innerHTML on every WebSocket push that doesn't affect us
+    // (e.g. a sibling item being added on a 50-card dashboard).
+    const renderKey = `${isOn}|${qty}|${matchedUid || ''}|${matched || ''}`;
+    if (this._lastRenderKey === renderKey) return;
+    this._lastRenderKey = renderKey;
 
     const onIcon    = this._config.on_icon    || ShoppingListCard.DEFAULT_ON_ICON;
     const offIcon   = this._config.off_icon   || ShoppingListCard.DEFAULT_OFF_ICON;
@@ -827,7 +840,7 @@ class ShoppingListCard extends HTMLElement {
         let iconElement;
         if (effectiveImage) {
             iconElement = `<div class="image-wrapper vertical-image">
-                             <img src="${safeImage}" alt="${safeTitle}" crossorigin="anonymous" />
+                             <img src="${safeImage}" alt="${safeTitle}" />
                              ${quantityBadge}
                              <div class="icon-wrapper vertical-icon" style="background:${bg}; color:${fg};">
                                <ha-icon icon="${icon}"></ha-icon>
@@ -857,7 +870,7 @@ class ShoppingListCard extends HTMLElement {
 
         if (effectiveImage) {
             mainContent = `<div class="image-wrapper">
-                             <img src="${safeImage}" alt="${safeTitle}" crossorigin="anonymous" />
+                             <img src="${safeImage}" alt="${safeTitle}" />
                              <div class="icon-wrapper" style="background:${bg}; color:${fg};">
                                <ha-icon icon="${icon}"></ha-icon>
                              </div>


### PR DESCRIPTION
﻿**Release: v2.0.1**

## 🐛 Bug Fixes

- **Fix external image URLs not loading.** Removed `crossorigin=""anonymous""` from the <img> tags in both layouts. With the attribute set, the browser loaded the image in CORS mode, so any external URL whose host did not return `Access-Control-Allow-Origin` (most arbitrary product image hosts) silently failed. The card never reads canvas pixels, so the attribute provided no benefit. Local `/local/...` images and CORS-enabled CDNs are unaffected; non-CORS external URLs now render.

## ⚡ Performance

- **Skip redundant renders.** `_render()` now memoizes its visible state (`isOn`, `qty`, matched UID/summary) and bails out when nothing changed for this card. On dashboards with many cards pointing at the same to-do list, every WebSocket push from a sibling card no longer triggers a full DOM rebuild on every other card. Config changes invalidate the memo via `setConfig`, and error renders reset it via `_renderError`.

## 📖 Docs

- Add **Downloads** badge to the README header (pairs with the release asset attached by the Release workflow).
- Replace 4 em dashes with regular `-` in the Options table.
- Promote `### ❤️ Support` to `## ❤️ Support` so it sits at the same level as the Examples section.

## 🛠️ Build

- Bump `actions/setup-node` from Node 20 to Node 22 in `release.yml` (Node 20 entered maintenance Oct 2025; 22 is the current LTS).
